### PR TITLE
Don't call detachInterrupt() inside ISR since it internally calls heap functions

### DIFF
--- a/src/PietteTech_DHT.h
+++ b/src/PietteTech_DHT.h
@@ -64,6 +64,7 @@ const int  DHTLIB_ERROR_DELTA            = -6;
 const int  DHTLIB_ERROR_NOTSTARTED       = -7;
 
 #define DHT_CHECK_STATE                    \
+        detachISRIfRequested();            \
         if(_state == STOPPED)              \
             return _status;			           \
         else if(_state != ACQUIRED)		     \
@@ -104,6 +105,7 @@ public:
 private:
   void _isrCallback();
   void convert();
+  void detachISRIfRequested();
 
   enum states { RESPONSE = 0, DATA = 1, ACQUIRED = 2, STOPPED = 3, ACQUIRING = 4 };
   volatile states _state;
@@ -113,6 +115,7 @@ private:
   volatile uint8_t _idx;
   volatile unsigned long _us;
   volatile bool _convert;
+  volatile bool _detachISR;
 #if defined(DHT_DEBUG_TIMING)
   volatile uint8_t *_e;
 #endif


### PR DESCRIPTION
Resolves #1 (DeviceOS 1.2.1-rc.3 safety checks break library), also tracked under https://github.com/particle-iot/device-os/issues/1835.

I've created a flag `_detachISR` that the ISR code can use to request that main thread code detach the ISR. I'm not thrilled with how I baked in the check for `_detachISR` (in `DHT_CHECK_STATE` and `getStatus`) but I think this just creates the least amount of churn.

For completeness' sake it may be worth investing in a destructor that calls `detachISRIfRequested` to make it feel more complete, though I bet that nobody in real life actually has a transient object for any of this...

Regardless, happy to make any changes you'd like to see.

Sniff-tested on Photon with DeviceOS 1.2.1.