### PR TITLE
Fix hang condition when no data is returned.

### DIFF
--- a/src/PietteTech_DHT.cpp
+++ b/src/PietteTech_DHT.cpp
@@ -171,6 +171,10 @@ int PietteTech_DHT::acquireAndWait(uint32_t timeout) {
   if (acquiring())
   {
     _status = DHTLIB_ERROR_RESPONSE_TIMEOUT;
+    if (_state == RESPONSE) {
+      _state = STOPPED;
+      _detachISR = true;
+    }
   }
   return getStatus();
 }


### PR DESCRIPTION
When there is no response (and therefore no interrupt) from the DHT device after acquire() is triggered, the state machine is left in the RESPONSE state with the ISR attached.  While the ISR is attached, calling attach() again doesn't actually signal the DHT device because pinMode doesn't set the pin to OUTPUT mode.  This change detects that failure and resets the state machine and the detaches the ISR.